### PR TITLE
added cluster name to pattern to fix http multiple registrations error

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,11 +216,12 @@ func start_app(config Config) {
 			os.Exit(1)
 		}
 
+
 		// Each cluster gets a different login and callback URL
 		http.HandleFunc(base_redirect_uri.Path, cluster.handleCallback)
 		log.Printf("Registered callback handler at: %s", base_redirect_uri.Path)
 
-		http.HandleFunc("/script", cluster.handleScript)
+		http.HandleFunc("/script"+cluster.Name, cluster.handleScript)
 		log.Printf("Registered script callback handler at: %s", "/script")
 
 		login_uri := path.Join(config.Web_Path_Prefix, "login", cluster.Name)


### PR DESCRIPTION
```
panic: http: multiple registrations for /script
goroutine 1 [running]:
net/http.(*ServeMux).Handle(0xc0000a3580, 0x97c6c3, 0x7, 0xa360c0, 0xc00014fc50)
	/usr/local/go/src/net/http/server.go:2391 +0x29c
net/http.(*ServeMux).HandleFunc(...)
	/usr/local/go/src/net/http/server.go:2428
main.start_app(0xc00006f180, 0x2, 0x2, 0xc00009f3a0, 0x13, 0xd8200f, 0x1, 0x0, 0x0, 0x0, ...)
	/app/main.go:225 +0xb42
main.glob..func1(0xdbac20, 0xc0001fdad0, 0x0, 0x3)
	/app/main.go:323 +0x344
github.com/spf13/cobra.(*Command).execute(0xdbac20, 0xc0000a2050, 0x3, 0x3, 0xdbac20, 0xc0000a2050)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0xdbac20, 0x97fa00, 0xc000117f88, 0x40756f)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fc
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/app/main.go:375 +0x32
```