### PR TITLE
remove exposed secret:

### DIFF
--- a/templates/commands.html
+++ b/templates/commands.html
@@ -31,8 +31,6 @@ kubectl config set-credentials {{ .Username }}-{{ .ClusterName }} \
   --auth-provider=oidc \
   --auth-provider-arg=idp-issuer-url={{ .Issuer }} \
   --auth-provider-arg=client-id={{ .ClientID }} \
-  --auth-provider-arg=client-secret={{ .ClientSecret }} \
-  --auth-provider-arg=refresh-token={{ .RefreshToken }} \
   --auth-provider-arg=id-token={{ .IDToken }}
 {{- if or (.IDPCaURI) (.IDPCaPem) }} \
   --auth-provider-arg=idp-certificate-authority=${HOME}/.kube/certs/{{ .ClusterName }}/idp-ca.crt


### PR DESCRIPTION
Not sure how this is deployed currently?

I tested locally and client-secret isn't needed, and exposes well the client-secret